### PR TITLE
Generalize methods to use MonadIO class, and bracket exceptions in the computation.

### DIFF
--- a/system-posix-redirect.cabal
+++ b/system-posix-redirect.cabal
@@ -33,7 +33,11 @@ Library
   Exposed-modules:      System.Posix.Redirect
   Extensions:           ForeignFunctionInterface,
                         EmptyDataDecls
-  Build-depends:        base >= 4 && < 5, bytestring >= 0.9, unix >= 2.4.0
+  Build-depends:        base >= 4 && < 5,
+                        bytestring >= 0.9,
+                        unix >= 2.4.0,
+                        MonadCatchIO-transformers >= 0.2.0.0,
+                        transformers >= 0.2.0.0
   C-sources:            cbits/hsredirect.c
   Include-dirs:         include
   Install-includes:     include/hsredirect.h


### PR DESCRIPTION
This change cleans up old resources if the computation throws an exception.
